### PR TITLE
hide generated dates

### DIFF
--- a/src/package-scripts.js
+++ b/src/package-scripts.js
@@ -8,7 +8,7 @@ module.exports = {
   'preversion': 'git checkout master && git pull && npm ls', // eslint-disable-line
   'docs': [ // eslint-disable-line
     'mkdir -p docs &&',
-    'jsdoc -c .jsdoc.json -t ./node_modules/minami -d docs -R README.md -r src/',
+    'jsdoc -c .jsdoc.json src/',
   ].join(' '),
   'deploy-docs': 'gh-pages -d docs && rm -rf docs',
   'postpublish': 'npm run docs && npm run deploy-docs', // eslint-disable-line

--- a/templates/.jsdoc.json
+++ b/templates/.jsdoc.json
@@ -1,3 +1,14 @@
 {
-  "plugins": ["plugins/markdown"]
+  "opts": {
+      "template": "node_modules/minami",
+      "destination": "./docs",
+      "recurse": true,
+      "readme": "README.md"
+  },
+  "plugins": ["plugins/markdown"],
+  "templates": {
+      "default": {
+          "includeDate": false
+      }
+  }
 }


### PR DESCRIPTION
# problem statements
- if docs are under version control, dates generate frivolous diffs
- the cmd is suuper long

# solution
- don't generate doc date stamps
- hide complexity into the existing jsdoc.json