### PR TITLE
feature/istanbul-to-nyc

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ const devPackages = [
   'eslint-plugin-react',
   'gh-pages',
   'jsdoc',
-  'istanbul',
+  'nyc',
   'minami',
 ];
 

--- a/src/package-scripts.js
+++ b/src/package-scripts.js
@@ -1,7 +1,7 @@
 const lintDirs = 'src/ test/';
 module.exports = {
-  'test': 'istanbul cover test/', // eslint-disable-line
-  'postest': 'istanbul check --statements 90 --functions 90 --branches 90', // eslint-disable-line
+  'test': 'nyc node test/', // eslint-disable-line
+  'postest': 'nyc check-coverage --lines 95 --functions 95 --branches 95', // eslint-disable-line
   'lint': 'eslint ' + lintDirs, // eslint-disable-line
   'lintfix': 'eslint --fix ' + lintDirs, // eslint-disable-line
   'validate': 'npm ls', // eslint-disable-line

--- a/src/package-scripts.js
+++ b/src/package-scripts.js
@@ -1,7 +1,7 @@
 const lintDirs = 'src/ test/';
 module.exports = {
   'test': 'nyc node test/', // eslint-disable-line
-  'postest': 'nyc check-coverage --lines 95 --functions 95 --branches 95', // eslint-disable-line
+  'postest': 'nyc check-coverage --lines 90 --functions 90 --branches 90', // eslint-disable-line
   'lint': 'eslint ' + lintDirs, // eslint-disable-line
   'lintfix': 'eslint --fix ' + lintDirs, // eslint-disable-line
   'validate': 'npm ls', // eslint-disable-line


### PR DESCRIPTION
# problem statement
- istanbul doesn't work with multiprocess programs

# solution
- use nyc, which wraps istanbul and handles multiprocess apps.  raynos recommended it in the istanbul threads